### PR TITLE
fix: removed aggressive pattern matching for negative words in worksp…

### DIFF
--- a/functions/workspaces/helpers.ts
+++ b/functions/workspaces/helpers.ts
@@ -499,8 +499,10 @@ const normalizeText = (text: string): string => {
 };
 
 const checkWordBoundaries = (text: string, badWord: string): boolean => {
+  // Escape special regex characters
+  const escaped = badWord.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // Only check whole word matches, not substrings
-  const regex = new RegExp(`\\b${badWord}\\b`, 'i');
+  const regex = new RegExp(`\\b${escaped}\\b`, 'i');
   return regex.test(text);
 };
 


### PR DESCRIPTION
…ace creation

## What

Less aggressive pattern matching for negative keywords in workspace names.

## Why

Company names like "AcmeCorp" and "B2BSaaS" were being flagged as negative words.

## How

1. Word Boundary Matching Only: Changed
  checkWordBoundaries to only use regex word boundaries
  (\b), removing the aggressive substring matching that was
  causing "cum" in "Acme" and "ass" in "b2bsaas".
  2. Less Aggressive Normalization: Changed repeated
  character removal from 2+ to 3+ repetitions, so legitimate
   double letters aren't removed.
  3. Removed Substring Checks: Removed the .includes()
  checks that were finding profanity inside legitimate
  words.
  
## Testing

- [x] Tested locally with `npm run local:dev`

**Testing Details:**
Created a new workspace with "Acme Corp." which previously failed.

## Deployment Notes

- [ ] SAM template updated (if new Lambda functions/resources)
- [ ] Environment variables documented (if new ones added)
- [x] No breaking API changes (or documented below)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Complex code documented
- [ ] Related issues linked

## Related Issues

<!-- Link related issues using "Fixes #123" or "Closes #123" -->

## Breaking Changes

<!-- If this introduces breaking changes, describe them here -->

## Additional Notes

<!-- Any additional context or areas where you'd like specific feedback -->
