### PR TITLE
feat: allow vercel preview links

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Mappings:
       url: 'https://app.pager.team'
   AllowOrigins:
     dev:
-      origins: http://localhost:3000,https://pager-dev.vercel.app
+      origins: http://localhost:3000,https://pager-dev.vercel.app,https://pager-frontend-git-skeleton-loaders-zachs-projects-3b56783e.vercel.app
     prod:
       origins: https://app.pager.team
 
@@ -51,6 +51,8 @@ Globals:
         PG_DATABASE: !Sub '{{resolve:secretsmanager:/${StackName}/${Environment}/pg-database:SecretString}}'
         PG_PASSWORD: !Sub '{{resolve:secretsmanager:/${StackName}/${Environment}/pg-password:SecretString}}'
         PG_PORT: !Sub '{{resolve:secretsmanager:/${StackName}/${Environment}/pg-port:SecretString}}'
+        VERCEL_PROJECTS: pager-frontend
+        ALLOW_VERCEL_PREVIEWS: true
         FRONTEND_URL: !FindInMap
           - FrontendUrls
           - !Ref Environment


### PR DESCRIPTION
## What

Allow vercel preview links to work with aws lambdas

## Why

Lambdas would return 403 when using preview links because they were blocked by CORS

## How

Updated cors middleware to accept vercel preview links by using regex matching. We also have new env variables to set the vercel project id and whether to accept the vercel preview links

## Testing

- [x] Tested locally with `npm run local:dev`

## Deployment Notes

- [x] SAM template updated (if new Lambda functions/resources)
- [x] Environment variables documented (if new ones added)
- [x] No breaking API changes (or documented below)

## Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Complex code documented
- [ ] Related issues linked

## Related Issues

<!-- Link related issues using "Fixes #123" or "Closes #123" -->

## Breaking Changes

<!-- If this introduces breaking changes, describe them here -->

## Additional Notes

<!-- Any additional context or areas where you'd like specific feedback -->
